### PR TITLE
Log verification exceptions

### DIFF
--- a/lib/services/campfire.rb
+++ b/lib/services/campfire.rb
@@ -48,7 +48,7 @@ class Service::Campfire < Service::Base
     rescue ::Tinder::AuthenticationFailed => e
       [false, 'Oops! Is your API token correct?']
     rescue => e
-      log "Rescued a verification error. #{e}"
+      log "Rescued a verification error in campfire: #{e}"
       [false, "Oops! Encountered an unexpected error (#{e}). Please check your settings."]
   end
 

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -74,7 +74,7 @@ class Service::Jira < Service::Base
       [false, "Oops! Please check your settings again."]
     end
   rescue => e
-    log e
+    log "Rescued a verification error in jira: (url=#{config[:project_url]}) #{e}"
     [false, "Oops! Is your project url correct?"]
   end
 

--- a/lib/services/pivotal.rb
+++ b/lib/services/pivotal.rb
@@ -66,7 +66,7 @@ class Service::Pivotal < Service::Base
       [false, "Oops! Please check your settings again."]
     end
   rescue => e
-    log "Rescued a verification error. Most likely due to a malformed url: #{ config[:project_url] }"
+    log "Rescued a verification error in pivotal: (url=#{config[:project_url]}) #{e}"
     [false, "Oops! Is your project url correct?"]
   end
 

--- a/lib/services/redmine.rb
+++ b/lib/services/redmine.rb
@@ -67,7 +67,7 @@ class Service::Redmine < Service::Base
       [false, "Oops! Please check your settings again."]
     end
   rescue => e
-    log "Rescued a verification error. Most likely due to a malformed url: #{ config[:project_url] }"
+    log "Rescued a verification error in redmine: (url=#{config[:project_url]}) #{e}"
     [false, "Oops! Is your project url correct?"]
   end
 

--- a/lib/services/web_hook.rb
+++ b/lib/services/web_hook.rb
@@ -20,7 +20,7 @@ class Service::WebHook < Service::Base
     ok = post_event(config[:url], 'verification', 'none', nil)
     ok ? success : failure
   rescue => e
-    log "Rescued a verification error. Most likely due to a malformed url: #{ config[:url] }"
+    log "Rescued a verification error in webhook: (url=#{config[:url]}) #{e}"
     failure
   end
 


### PR DESCRIPTION
Should help us diagnose customer issues with integrations.

The url that failed to verify is still logged.
