### PR TITLE
Copy updates and whitespace cleanup for services

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    crashlytics-service (3.5.0)
+    crashlytics-service (3.5.1)
       asana (= 0.0.4)
       faraday (= 0.8.1)
       hipchat (~> 0.7.0)

--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end

--- a/lib/services/campfire.rb
+++ b/lib/services/campfire.rb
@@ -2,7 +2,7 @@ require 'tinder'
 
 class Service::Campfire < Service::Base
   title 'Campfire'
-  
+
   string :subdomain, :label => 'Your Campfire subdomain:'
   string :room, :label => 'Your Campfire chatroom:'
   string :api_token, :label => "Get it from Campfire's \"My Info\" screen."

--- a/lib/services/github.rb
+++ b/lib/services/github.rb
@@ -15,7 +15,7 @@ class Service::GitHub < Service::Base
 
   def receive_verification(config, _)
     repo = github_repo(config[:access_token], config[:repo])
-    [true, "Successsfully accessed repo #{config[:repo]}."]
+    [true, "Successfully accessed repo #{config[:repo]}."]
   rescue => e
     log "Rescued a verification error in GitHub for repo #{config[:repo]}: #{e}"
     [false, "Could not access repository for #{config[:repo]}."]

--- a/lib/services/hipchat.rb
+++ b/lib/services/hipchat.rb
@@ -46,7 +46,7 @@ class Service::HipChat < Service::Base
   def send_message(config, message)
     token = config[:api_token]
     room = config[:room]
-    client = HipChat::Client.new(token)    
+    client = HipChat::Client.new(token)
     client[room].send('Crashlytics', message, :notify => config[:notify]) 
   end
 end

--- a/lib/services/pagerduty.rb
+++ b/lib/services/pagerduty.rb
@@ -1,10 +1,10 @@
 class Service::Pagerduty < Service::Base
   title 'Pagerduty'
-  
+
   string :api_key, :label => 'Create a new Pagerduty service using the Generic API, then paste the API key here.',
     :placeholder => 'Pagerduty API key'
   page "API Key", [:api_key]
-  
+
   # Create an issue on Pagerduty
   def receive_issue_impact_change(config, payload)
     resp = post_event('issue_impact_change', 'issue', payload)
@@ -22,15 +22,15 @@ class Service::Pagerduty < Service::Base
     else
       log "Receive verification failed, most likely due to a bad API key: #{config[:api_key]}, API response: #{resp[:status]}"
       [false, 'Oops! Please check your API key again.']
-    end  
+    end
   end
 
-  private 
+  private
   def post_event(event, payload_type, payload)
     url = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
     issue_description = ""
     issue_details = {}
-    
+
     if event == 'verification'
       issue_description = '[Crashlytics] Pagerduty settings verified!'
     elsif event == 'issue_impact_change'
@@ -40,14 +40,14 @@ class Service::Pagerduty < Service::Base
         'crashes' => payload[:crashes_count],
       }
     end
-      
-    post_body = {    
+
+    post_body = {
       'service_key' => config[:api_key],
       'event_type' => 'trigger',
       'description' => issue_description,
       'details' => issue_details
-    }    
-    
+    }
+
     resp = http_post url do |req|
       req.headers['Content-Type'] = 'application/json'
       req.body                    = post_body.to_json

--- a/lib/services/sprintly.rb
+++ b/lib/services/sprintly.rb
@@ -1,79 +1,79 @@
 class Service::Sprintly < Service::Base
-	title 'Sprint.ly'
+  title 'Sprint.ly'
 
-	string :dashboard_url, :placeholder => 'https://sprint.ly/product/1/',
-	       :label => 'URL for your Sprint.ly product dashboard'
-	string :email, :placeholder => 'email',
-	       :label => 'These values are encrypted to ensure your security. <br /><br />' \
+  string :dashboard_url, :placeholder => 'https://sprint.ly/product/1/',
+         :label => 'URL for your Sprint.ly product dashboard'
+  string :email, :placeholder => 'email',
+         :label => 'These values are encrypted to ensure your security. <br /><br />' \
                    'Your Sprint.ly email:'
-	password :api_key, :placeholder => 'Sprint.ly API key',
-	         :label => 'Your Sprint.ly API key:'
+  password :api_key, :placeholder => 'Sprint.ly API key',
+           :label => 'Your Sprint.ly API key:'
 
-	page 'Product', [:dashboard_url]
-	page 'Login Information', [:email, :api_key]
+  page 'Product', [:dashboard_url]
+  page 'Login Information', [:email, :api_key]
 
-	def receive_verification(config, _)
-		begin
-			url = items_api_url_from_dashboard_url(config[:dashboard_url])
-			http.ssl[:verify] = true
-			http.basic_auth config[:email], config[:api_key]
+  def receive_verification(config, _)
+    begin
+      url = items_api_url_from_dashboard_url(config[:dashboard_url])
+      http.ssl[:verify] = true
+      http.basic_auth config[:email], config[:api_key]
 
-			resp = http_get url
-			if resp.status == 200
-				[true,  'Successfully verified Sprint.ly settings!']
-			else
-				log "Sprint.ly HTTP Error, status code: #{ resp.status }, body: #{ resp.body }"
-				[false, "Oops! Please check your settings again."]
-			end
-		rescue => e
-			log "Rescued a verification error in Sprint.ly: (url=#{config[:dashboard_url]}) #{e}"
-			[false, "Oops! Please check your settings again."]
-		end
-	end
+      resp = http_get url
+      if resp.status == 200
+        [true,  'Successfully verified Sprint.ly settings!']
+      else
+        log "Sprint.ly HTTP Error, status code: #{ resp.status }, body: #{ resp.body }"
+        [false, "Oops! Please check your settings again."]
+      end
+    rescue => e
+      log "Rescued a verification error in Sprint.ly: (url=#{config[:dashboard_url]}) #{e}"
+      [false, "Oops! Please check your settings again."]
+    end
+  end
 
-	# Create a defect on Sprint.ly
-	def receive_issue_impact_change(config, payload)
-		url = items_api_url_from_dashboard_url(config[:dashboard_url])
-		http.ssl[:verify] = true
-		http.basic_auth config[:email], config[:api_key]
+  # Create a defect on Sprint.ly
+  def receive_issue_impact_change(config, payload)
+    url = items_api_url_from_dashboard_url(config[:dashboard_url])
+    http.ssl[:verify] = true
+    http.basic_auth config[:email], config[:api_key]
 
-		post_body = {
-			:type => 'defect',
-			:title => payload[:title] + ' [Crashlytics]',
-			:description => sprintly_issue_description(payload)
-		}
+    post_body = {
+      :type => 'defect',
+      :title => payload[:title] + ' [Crashlytics]',
+      :description => sprintly_issue_description(payload)
+    }
 
-		resp = http_post url do |req|
-			req.body = post_body
-		end
-		raise "[Sprint.ly] Adding defect to backlog failed: #{ resp[:status] }, body: #{ resp.body }" unless resp.status == 200
-		{ :sprintly_item_number => JSON.parse(resp.body)['number'] }
-	end
+    resp = http_post url do |req|
+      req.body = post_body
+    end
+    raise "[Sprint.ly] Adding defect to backlog failed: #{ resp[:status] }, body: #{ resp.body }" unless resp.status == 200
+    { :sprintly_item_number => JSON.parse(resp.body)['number'] }
+  end
 
-	private
-	def sprintly_issue_description(payload)
-		users_text = if payload[:impacted_devices_count] == 1
-			"This issue is affecting at least 1 user who has crashed "
-		else
-			"This issue is affecting at least #{ payload[:impacted_devices_count] } users who have crashed "
-		end
+  private
+  def sprintly_issue_description(payload)
+    users_text = if payload[:impacted_devices_count] == 1
+      "This issue is affecting at least 1 user who has crashed "
+    else
+      "This issue is affecting at least #{ payload[:impacted_devices_count] } users who have crashed "
+    end
 
-		crashes_text = if payload[:crashes_count] == 1
-			"at least 1 time."
-		else
-			"at least #{ payload[:crashes_count] } times."
-		end
+    crashes_text = if payload[:crashes_count] == 1
+      "at least 1 time."
+    else
+      "at least #{ payload[:crashes_count] } times."
+    end
 
-		"Crashlytics detected a new issue.\n" + \
+    "Crashlytics detected a new issue.\n" + \
        "#{ payload[:title] } in #{ payload[:method] }\n\n" + \
        users_text + crashes_text + "\n\n" + \
        "More information: #{ payload[:url] }"
   end
 
-	require 'uri'
-	def items_api_url_from_dashboard_url(url)
-		uri = URI(url)
-		product_id = url.match(/(https?:\/\/.*?)\/product\/(\d*)(\/|$)/)[2]
-		"https://sprint.ly/api/products/#{product_id}/items.json"
-	end
+  require 'uri'
+  def items_api_url_from_dashboard_url(url)
+    uri = URI(url)
+    product_id = url.match(/(https?:\/\/.*?)\/product\/(\d*)(\/|$)/)[2]
+    "https://sprint.ly/api/products/#{product_id}/items.json"
+  end
 end

--- a/lib/services/youtrack.rb
+++ b/lib/services/youtrack.rb
@@ -1,7 +1,7 @@
 class Service::YouTrack < Service::Base
   title 'YouTrack'
 
-  string :base_url, :label => 'URL to YouTrack server:', :placeholder => 'http://myname.jetbrains.com/youtrack/'
+  string :base_url, :label => 'URL to YouTrack server:', :placeholder => 'https://myname.jetbrains.com/youtrack/'
   string :project_id, :label => 'YouTrack Project ID:', :placeholder => 'PROJ'
   string :username, :label => 'Email address:', :placeholder => 'user@domain.com'
   password :password, :label => 'Password:'

--- a/spec/services/asana_spec.rb
+++ b/spec/services/asana_spec.rb
@@ -47,14 +47,14 @@ describe Service::Asana do
         response = service.receive_verification(config, nil)
         response.should == [true, 'Successfully verified Asana settings!']
       end
-      
+
       it 'should fail if API call raises an exception' do
         service.should_receive(:find_project).and_raise
         response = service.receive_verification(config, nil)
         response.first.should == false
       end
     end
-  
+
     describe :receive_issue_impact_change do
       let(:notes) { service.send :create_notes, issue }
       let(:project_id) { 'project_id_foo' }
@@ -68,7 +68,7 @@ describe Service::Asana do
       let(:project) { mock(:id => project_id) }
       let(:workspace) { mock(:id => 'workspace_id_foo') }
       let(:task) { mock(:id => 'new_task_id') }
-      
+
       it 'should create a new Asana task' do
         service.should_receive(:find_project).with(config[:api_key], project_id).and_return project
         project.should_receive(:workspace).and_return workspace
@@ -77,12 +77,12 @@ describe Service::Asana do
         response = service.receive_issue_impact_change config, issue
         response.should == { :asana_task_id => task.id }
       end
-      
+
       it 'should raise if creating a new Asana task fails' do
         service.should_receive(:find_project).with(config[:api_key], project_id).and_return project
         project.should_receive(:workspace).and_return workspace
         workspace.should_receive(:create_task).with(expected_task_options).and_raise
-  
+
         expect { service.receive_issue_impact_change config, issue }.to raise_error
       end
     end

--- a/spec/services/github_spec.rb
+++ b/spec/services/github_spec.rb
@@ -26,7 +26,7 @@ describe Service::GitHub do
 
       success, message = service.receive_verification(config, nil)
       success.should be_true
-      message.should == 'Successsfully accessed repo crashlytics/sample-project.'
+      message.should == 'Successfully accessed repo crashlytics/sample-project.'
     end
 
     it :failure do

--- a/spec/services/sprintly_spec.rb
+++ b/spec/services/sprintly_spec.rb
@@ -1,107 +1,107 @@
 require 'spec_helper'
 
 describe Service::Sprintly do
-	it 'should have a title' do
-		Service::Sprintly.title.should == 'Sprint.ly'
-	end
+  it 'should have a title' do
+    Service::Sprintly.title.should == 'Sprint.ly'
+  end
 
   describe :receive_verification do
-  	let(:service) { Service::Sprintly.new('event_name', {}) }
+    let(:service) { Service::Sprintly.new('event_name', {}) }
     let(:config) do
-    	{
-    		:dashboard_url => 'https://sprint.ly/product/1/'
-    	}
+      {
+        :dashboard_url => 'https://sprint.ly/product/1/'
+      }
     end
-  	let(:payload) { {} }
+    let(:payload) { {} }
 
-  	it 'should respond' do
-			service.respond_to?(:receive_verification)
-		end
+    it 'should respond' do
+      service.respond_to?(:receive_verification)
+    end
 
-		it 'should succeed upon successful api response' do
-			test = Faraday.new do |builder|
-				builder.adapter :test do |stub|
-					stub.get('/api/products/1/items.json') { [200, {}, ''] }
-				end
-			end
+    it 'should succeed upon successful api response' do
+      test = Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.get('/api/products/1/items.json') { [200, {}, ''] }
+        end
+      end
 
-			service.should_receive(:http_get)
-				.with('https://sprint.ly/api/products/1/items.json')
-				.and_return(test.get('/api/products/1/items.json'))
+      service.should_receive(:http_get)
+        .with('https://sprint.ly/api/products/1/items.json')
+        .and_return(test.get('/api/products/1/items.json'))
 
-			resp = service.receive_verification(config, payload)
-			resp.should == [true, 'Successfully verified Sprint.ly settings!']
-		end
+      resp = service.receive_verification(config, payload)
+      resp.should == [true, 'Successfully verified Sprint.ly settings!']
+    end
 
-		it 'should fail upon unsuccessful api response' do
-			test = Faraday.new do |builder|
-				builder.adapter :test do |stub|
-					stub.get('/api/products/1/items.json') { [500, {}, ''] }
-				end
-			end
+    it 'should fail upon unsuccessful api response' do
+      test = Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.get('/api/products/1/items.json') { [500, {}, ''] }
+        end
+      end
 
-			service.should_receive(:http_get)
-				.with('https://sprint.ly/api/products/1/items.json')
-				.and_return(test.get('/api/products/1/items.json'))
+      service.should_receive(:http_get)
+        .with('https://sprint.ly/api/products/1/items.json')
+        .and_return(test.get('/api/products/1/items.json'))
 
-			resp = service.receive_verification(config, payload)
-			resp.should == [false, 'Oops! Please check your settings again.']
-		end
-	end
+      resp = service.receive_verification(config, payload)
+      resp.should == [false, 'Oops! Please check your settings again.']
+    end
+  end
 
-	describe :receive_issue_impact_change do
-		let(:service) { Service::Sprintly.new('event_name', {}) }
+  describe :receive_issue_impact_change do
+    let(:service) { Service::Sprintly.new('event_name', {}) }
     let(:config) do
-    	{
-    		:dashboard_url => 'https://sprint.ly/product/1/'
-    	}
+      {
+        :dashboard_url => 'https://sprint.ly/product/1/'
+      }
     end
-		let(:payload) do
-			{
-					:title => 'foo title',
-					:impact_level => 1,
-					:impacted_devices_count => 1,
-					:crashes_count => 1,
-					:app => {
-							:name => 'foo name',
-							:bundle_identifier => 'foo.bar.baz'
-					}
-			}
-		end
+    let(:payload) do
+      {
+          :title => 'foo title',
+          :impact_level => 1,
+          :impacted_devices_count => 1,
+          :crashes_count => 1,
+          :app => {
+              :name => 'foo name',
+              :bundle_identifier => 'foo.bar.baz'
+          }
+      }
+    end
 
-		it 'should respond to receive_issue_impact_change' do
-			service.respond_to?(:receive_issue_impact_change)
-		end
+    it 'should respond to receive_issue_impact_change' do
+      service.respond_to?(:receive_issue_impact_change)
+    end
 
-		it 'should succeed upon successful api response' do
-			test = Faraday.new do |builder|
-				builder.adapter :test do |stub|
-					stub.post('/api/products/1/items.json') { [200, {}, { number: '42' }.to_json] }
-					stub.get('/api/products/1/items.json') { [200, {}, ""] }
-				end
-			end
+    it 'should succeed upon successful api response' do
+      test = Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.post('/api/products/1/items.json') { [200, {}, { number: '42' }.to_json] }
+          stub.get('/api/products/1/items.json') { [200, {}, ""] }
+        end
+      end
 
-			service.should_receive(:http_post)
-				.with('https://sprint.ly/api/products/1/items.json')
-				.and_return(test.post('/api/products/1/items.json'))
+      service.should_receive(:http_post)
+        .with('https://sprint.ly/api/products/1/items.json')
+        .and_return(test.post('/api/products/1/items.json'))
 
-			resp = service.receive_issue_impact_change(config, payload)
-			resp.should == { :sprintly_item_number => '42' }
-		end
+      resp = service.receive_issue_impact_change(config, payload)
+      resp.should == { :sprintly_item_number => '42' }
+    end
 
-		it 'should fail upon unsuccessful api response' do
-			test = Faraday.new do |builder|
-				builder.adapter :test do |stub|
-					stub.post('/api/products/1/items.json') { [500, {}, ""] }
-					stub.get('/api/products/1/items.json') { [200, {}, ""] }
-				end
-			end
+    it 'should fail upon unsuccessful api response' do
+      test = Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.post('/api/products/1/items.json') { [500, {}, ""] }
+          stub.get('/api/products/1/items.json') { [200, {}, ""] }
+        end
+      end
 
-			service.should_receive(:http_post)
-				.with('https://sprint.ly/api/products/1/items.json')
-				.and_return(test.post('/api/products/1/items.json'))
+      service.should_receive(:http_post)
+        .with('https://sprint.ly/api/products/1/items.json')
+        .and_return(test.post('/api/products/1/items.json'))
 
-			lambda { service.receive_issue_impact_change(config, payload) }.should raise_error
-		end
-	end
+      lambda { service.receive_issue_impact_change(config, payload) }.should raise_error
+    end
+  end
 end


### PR DESCRIPTION
- Bumped version from 3.5.0 to 3.5.1
- Updated hint text for YouTrack from http:// to https:// which is
  supported (but not enforced).
- Fixed a typo in the confirmation message for Github.
- Fixed whitespace in campfire, pagerduty, hipchat, sprintly, and some
  specs.

The key files with real changes are:

  lib/services/youtrack.rb
  lib/services/github.rb
