### PR TITLE
Feature/fix webhook error reporting

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.5.3'
+  VERSION = '3.5.4'
 end

--- a/lib/services/web_hook.rb
+++ b/lib/services/web_hook.rb
@@ -12,7 +12,7 @@ class Service::WebHook < Service::Base
       # return :no_resource if we don't have a resource identifier to save
       :no_resource
     else
-      raise "Web Hook Issue Create Failed: #{ payload }"
+      raise "WebHook issue create failed: HTTP status code: #{response.status}, body: #{response.body}"
     end
   end
 

--- a/spec/services/web_hook_spec.rb
+++ b/spec/services/web_hook_spec.rb
@@ -82,10 +82,10 @@ describe Service::WebHook do
       resp.should == :no_resource
     end
 
-    it 'should fail upon unsuccessful api response' do
+    it 'should fail with extra information upon unsuccessful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.post('/') { [500, {}, ''] }
+          stub.post('/') { [500, {}, 'fake_body'] }
         end
       end
 
@@ -93,7 +93,9 @@ describe Service::WebHook do
         .with('https://example.org')
         .and_return(test.post('/'))
 
-      lambda { @service.receive_issue_impact_change(@config, @payload) }.should raise_error
+      lambda {
+        @service.receive_issue_impact_change(@config, @payload)
+      }.should raise_error(/WebHook issue create failed: HTTP status code: 500, body: fake_body/)
     end
   end
 end


### PR DESCRIPTION
Switch the webhook integration from reporting the information we tried to send to reporting the information returned by the webhook server.  This should help tremendously with troubleshooting the reason for failures.
