### PR TITLE
Fix Jira http-based integrations

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.5.4'
+  VERSION = '3.5.5'
 end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -143,6 +143,20 @@ class Service::Jira < Service::Base
    false
   end
 
+  def jira_client(config)
+    ssl_enabled = (URI(config[:project_url]).scheme == 'https')
+    ssl_verify_mode = ssl_enabled ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+    JIRA::Client.new(
+      :username =>     config[:username],
+      :password =>     config[:password],
+      :site =>         config[:project_url],
+      :context_path => '',
+      :auth_type =>    :basic,
+      :use_ssl =>      ssl_enabled,
+      :ssl_verify_mode => ssl_verify_mode
+    )
+  end
+
   private
   require 'uri'
   def parse_url(url)
@@ -150,16 +164,6 @@ class Service::Jira < Service::Base
     result = { :url_prefix => url.match(/(https?:\/\/.*?)\/browse\//)[1],
       :project_key => uri.path.match(/\/browse\/(.+?)(\/|$)/)[1]}
     result
-  end
-
-  def jira_client(config)
-    JIRA::Client.new({
-      :username=>     config[:username],
-      :password=>     config[:password],
-      :site=>         config[:project_url],
-      :context_path=> '',
-      :auth_type=>    :basic,
-      :use_ssl=>      true })
   end
 
   def callback_webhook_url(payload)

--- a/spec/services/jira_spec.rb
+++ b/spec/services/jira_spec.rb
@@ -36,6 +36,22 @@ describe Service::Jira do
     end
   end
 
+  describe 'jira_client' do
+    it 'disables SSL checking when the project_url is http' do
+      service = Service::Jira.new('verification', {})
+      client = service.jira_client(:project_url => 'http://example.com/browse/project_key')
+      expect(client.options[:use_ssl]).to be_false
+      expect(client.options[:ssl_verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
+    end
+
+    it 'enables SSL checking and peer verification when the project_url is https' do
+      service = Service::Jira.new('verification', {})
+      client = service.jira_client(:project_url => 'https://example.com/browse/project_key')
+      expect(client.options[:use_ssl]).to be_true
+      expect(client.options[:ssl_verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
+    end
+  end
+
   describe 'receive_issue_impact_change' do
     before do
       @config = { :project_url => 'https://example.com/browse/project_key' }


### PR DESCRIPTION
An issue introduced with 3.5.3 caused http-based JIRA integrations to
still attempt to use_ssl.  This ensures the http connection config
honors the scheme provided in the configuration.
