### PR TITLE
Patch/improve jira error reporting

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.5.9'
+  VERSION = '3.5.10'
 end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -54,13 +54,14 @@ class Service::Jira < Service::Base
       'description' => issue_description,
       'issuetype' => {'id' => '1'} } }
 
+    # The Jira client raises an HTTPError if the response is not of the type Net::HTTPSuccess
     resp = client.post("#{parsed[:url_prefix]}/rest/api/2/issue", post_body.to_json)
 
-    if resp.code != '201'
-      raise "Jira Issue Create Failed: #{ resp[:status] }, body: #{ resp.body }"
-    end
     body = JSON.parse(resp.body)
     { :jira_story_id => body['id'], :jira_story_key => body['key'] }
+
+  rescue JIRA::HTTPError => e
+    raise "Jira Issue Create Failed. Message: #{ e.message }, Status: #{ e.code }, Body: #{ e.response.body }"
   rescue => e
     raise "Jira Issue Create Failed: #{ e.message }"
   end

--- a/spec/services/jira_spec.rb
+++ b/spec/services/jira_spec.rb
@@ -98,7 +98,19 @@ describe Service::Jira do
          with(:headers => {'Accept'=>'application/json', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
          to_return(:status => 500, :body => "{\"id\":\"foo\"}", :headers => {})
 
-      lambda { @service.receive_issue_impact_change(@config, @payload) }.should raise_error
+      lambda { 
+        @service.receive_issue_impact_change(@config, @payload) 
+      }.should raise_error(/Status: 500, Body: {\"id\":\"foo\"}/)
+    end
+
+    it 'should handle and re-raise any non-HTTP errors' do
+      mock_client = double("Client")
+      mock_client.stub(:Project) {raise "Some Other Error"}
+      @service.stub(:jira_client).and_return(mock_client)
+
+      lambda {
+        @service.receive_issue_impact_change(@config, @payload)
+      }.should raise_error(/Jira Issue Create Failed: Some Other Error/)
     end
   end
 


### PR DESCRIPTION
Useful error info was getting discarded in the Jira hook.  This PR adds more helpful error messages.
