### PR TITLE
Handle scenario when username != repo owner

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.5.11'
+  VERSION = '3.5.12'
 end

--- a/spec/services/bitbucket_spec.rb
+++ b/spec/services/bitbucket_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 describe Service::Bitbucket do
 
   before do
-    @config = { :username => 'user_name', :repo => 'project_name' }
+    @config = { 
+      :username => 'user_name', 
+      :repo => 'project_name', 
+      :repo_owner => 'repo_owner' 
+    }
+    @invalid_repo_owners = [nil, " \t\n",  ""]
   end
 
   it 'should have a title' do
@@ -14,37 +19,58 @@ describe Service::Bitbucket do
     before do
       @service = Service::Bitbucket.new('verification', {})
       @payload = {}
+      @good_request_body = [200, {}, '']
+      @good_response = [true, 'Successfully verified Bitbucket settings']
     end
 
     it 'should respond' do
       @service.respond_to?(:receive_verification)
     end
 
+    it 'should use the username field in the repo url when the repo owner is missing' do
+      @invalid_repo_owners.each do |empty_value|
+        test = Faraday.new do |builder|
+          builder.adapter :test do |stub|
+            stub.get('api/1.0/repositories/user_name/project_name/issues') { @good_request_body }
+          end
+        end
+
+        @service.should_receive(:http_get)
+          .with('https://bitbucket.org/api/1.0/repositories/user_name/project_name/issues')
+          .and_return(test.get('/api/1.0/repositories/user_name/project_name/issues'))
+
+        @config[:repo_owner] = empty_value
+
+        resp = @service.receive_verification(@config, @payload)
+        resp.should == @good_response
+      end
+    end
+
     it 'should succeed upon successful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.get('api/1.0/repositories/user_name/project_name/issues') { [200, {}, ''] }
+          stub.get('api/1.0/repositories/repo_owner/project_name/issues') { @good_request_body }
         end
       end
 
       @service.should_receive(:http_get)
-        .with('https://bitbucket.org/api/1.0/repositories/user_name/project_name/issues')
-        .and_return(test.get('/api/1.0/repositories/user_name/project_name/issues'))
+        .with('https://bitbucket.org/api/1.0/repositories/repo_owner/project_name/issues')
+        .and_return(test.get('/api/1.0/repositories/repo_owner/project_name/issues'))
 
       resp = @service.receive_verification(@config, @payload)
-      resp.should == [true, 'Successfully verified Bitbucket settings']
+      resp.should == @good_response
     end
 
     it 'should fail upon unsuccessful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.get('/api/1.0/repositories/user_name/project_name/issues') { [500, {}, ''] }
+          stub.get('/api/1.0/repositories/repo_owner/project_name/issues') { [500, {}, ''] }
         end
       end
 
       @service.should_receive(:http_get)
-        .with('https://bitbucket.org/api/1.0/repositories/user_name/project_name/issues')
-        .and_return(test.get('/api/1.0/repositories/user_name/project_name/issues'))
+        .with('https://bitbucket.org/api/1.0/repositories/repo_owner/project_name/issues')
+        .and_return(test.get('/api/1.0/repositories/repo_owner/project_name/issues'))
 
       resp = @service.receive_verification(@config, @payload)
       resp.should == [false, 'Oops! Please check your settings again.']
@@ -64,37 +90,58 @@ describe Service::Bitbucket do
           :bundle_identifier => 'foo.bar.baz'
         }
       }
+      @good_request_body = [200, {}, "{\"local_id\":12345}"]
+      @good_response = { :bitbucket_issue_id => 12345 }
     end
 
     it 'should respond to receive_issue_impact_change' do
       @service.respond_to?(:receive_issue_impact_change)
     end
 
+    it 'should use the username field in the repo url when the repo owner is missing' do
+      @invalid_repo_owners.each do |empty_value|
+        test = Faraday.new do |builder|
+          builder.adapter :test do |stub|
+            stub.post('api/1.0/repositories/user_name/project_name/issues') { @good_request_body }
+          end
+        end
+
+        @service.should_receive(:http_post)
+          .with('https://bitbucket.org/api/1.0/repositories/user_name/project_name/issues')
+          .and_return(test.post('/api/1.0/repositories/user_name/project_name/issues'))
+
+        @config[:repo_owner] = empty_value
+
+        resp = @service.receive_issue_impact_change(@config, @payload)
+        resp.should == @good_response
+      end
+    end
+
     it 'should succeed upon successful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.post('/api/1.0/repositories/user_name/project_name/issues') { [200, {}, "{\"local_id\":12345}"] }
+          stub.post('/api/1.0/repositories/repo_owner/project_name/issues') { @good_request_body }
         end
       end
 
       @service.should_receive(:http_post)
-        .with('https://bitbucket.org/api/1.0/repositories/user_name/project_name/issues')
-        .and_return(test.post('/api/1.0/repositories/user_name/project_name/issues'))
+        .with('https://bitbucket.org/api/1.0/repositories/repo_owner/project_name/issues')
+        .and_return(test.post('/api/1.0/repositories/repo_owner/project_name/issues'))
 
       resp = @service.receive_issue_impact_change(@config, @payload)
-      resp.should == { :bitbucket_issue_id => 12345 }
+      resp.should == @good_response
     end
 
     it 'should fail upon unsuccessful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.post('/api/1.0/repositories/user_name/project_name/issues') { [500, {}, "fakebody"] }
+          stub.post('/api/1.0/repositories/repo_owner/project_name/issues') { [500, {}, "fakebody"] }
         end
       end
 
       @service.should_receive(:http_post)
-        .with('https://bitbucket.org/api/1.0/repositories/user_name/project_name/issues')
-        .and_return(test.post('/api/1.0/repositories/user_name/project_name/issues'))
+        .with('https://bitbucket.org/api/1.0/repositories/repo_owner/project_name/issues')
+        .and_return(test.post('/api/1.0/repositories/repo_owner/project_name/issues'))
 
       lambda { 
         @service.receive_issue_impact_change(@config, @payload) 


### PR DESCRIPTION
Previously, the Bitbucket service hook made the assumption that
the username and repo owner were always the same. This commit
adds a repo owner field to handle situations when this assumption
is wrong. If the repo owner field is missing, the hook should
fall back to using the username. Users that verified their
accounts using the previous version should not be affected.
