### PR TITLE
Fixed instructions for Bitbucket

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.5.12'
+  VERSION = '3.5.13'
 end

--- a/lib/services/bitbucket.rb
+++ b/lib/services/bitbucket.rb
@@ -24,13 +24,24 @@ class Service::Bitbucket < Service::Base
       'Limit the account\'s write access to the repo you want ' \
       'to post issues to.' \
       '<br /><br />' \
+      'Please make sure you have issues enabled for your Bitbucket ' \
+      'repository. Instructions for Bitbucket can be found here: ' \
+      'https://confluence.atlassian.com/display/BITBUCKET' \
+      '<br /><br />' \
+      'Example url: ' \
+      'https://bitbucket.org/example-owner/example-repo' \
+      '<br /><br />' \
       'Your Bitbucket username:'
   password :password, :placeholder => 'password',
      :label => 'Your Bitbucket password:'
-  string :repo_owner, :placeholder => "repository owner",
-     :label => 'The owner of your repo (enter your username again if you are the repo owner):'
-  string :repo, :placeholder => "repository",
-     :label => 'The name of your repo:'
+  string :repo_owner, :placeholder => 'example-owner',
+    :label => 
+      'The owner of your repo (enter your username again if you are the repo owner):'
+
+  string :repo, :placeholder => "example-repo",
+    :label => 
+      'The name of your repo:'
+
 
   page "Username", [:username]
   page "Password", [:password]


### PR DESCRIPTION
Bitbucket instructions needed some clarification. Changes include:
- Reminding users to turn on issues for Bitbucket
- Providing a sample url with helpful names for resources
- Changing placeholders to use the resource names in the sample url

The changes look like this:
![screen shot 2014-07-29 at 11 15 03 am](https://cloud.githubusercontent.com/assets/1487867/3754945/2449fe5c-1820-11e4-9f09-eb26465b1af0.png)
