### PR TITLE
Bump octokit to 3.7

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.8.0'
+  VERSION = '3.9.0'
 end

--- a/service.gemspec
+++ b/service.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'eventmachine', '1.0.0.beta.4'
   s.add_dependency 'hipchat', '~> 0.7'
   s.add_dependency 'asana', '0.0.4'
-  s.add_dependency 'octokit', '~> 2.0'
+  s.add_dependency 'octokit', '~> 3.7'
   s.add_dependency 'jira-ruby', '~> 0.1'
   s.add_dependency 'ruby-trello', '~> 1.1'
   s.add_dependency 'slack-notifier', '~> 1.0.0'


### PR DESCRIPTION
This is the latest version of the Github integration and includes a fix
for a bug in earlier versions of the client that caused our integration
with Github to stop working.
