### PR TITLE
Updating HipChat integration for HipChat Server

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.11.1'
+  VERSION = '3.12.0'
 end

--- a/lib/services/hipchat.rb
+++ b/lib/services/hipchat.rb
@@ -4,14 +4,16 @@ class Service::HipChat < Service::Base
   title 'HipChat'
 
   string :api_token, :placeholder => 'API Token',
-         :label => 'Your HipChat API Token. <br />' \
+         :label => 'Your HipChat API v1 Token. <br />' \
                    'You can create a notification token ' \
                    '<a href="https://www.hipchat.com/admin/api">here</a>.'
   string :room, :placeholder => 'Room ID or Name', :label => 'The ID or name of the room.'
   checkbox :notify, :label => 'Should a notification be triggered for people in the room?'
+  string :url, :placeholder => "https://api.hipchat.com", :label => 'The URL of the HipChat server.'
 
   page 'API Token', [:api_token]
   page 'Room', [:room, :notify]
+  page 'URL', [:url]
 
   def receive_verification(config, _)
     send_message(config, receive_verification_message)
@@ -46,7 +48,14 @@ class Service::HipChat < Service::Base
   def send_message(config, message)
     token = config[:api_token]
     room = config[:room]
-    client = HipChat::Client.new(token)
+    url = config[:url]
+    api_version = config[:v2] ? 'v2' : 'v1'
+    options = { :api_version => api_version }
+    server_url = url.to_s
+    unless server_url.empty?
+      options[:server_url] = server_url
+    end
+    client = HipChat::Client.new(token, options)
     client[room].send('Crashlytics', message, :notify => config[:notify]) 
   end
 end

--- a/service.gemspec
+++ b/service.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   # enforce consistency with worker pipeline version of eventmachine
   s.add_dependency 'eventmachine', '1.0.0.beta.4'
-  s.add_dependency 'hipchat', '~> 0.7'
+  s.add_dependency 'hipchat', '~> 1.4'
   s.add_dependency 'asana', '0.0.4'
   s.add_dependency 'octokit', '~> 3.7'
   s.add_dependency 'jira-ruby', '~> 0.1'

--- a/spec/services/hipchat_spec.rb
+++ b/spec/services/hipchat_spec.rb
@@ -50,7 +50,8 @@ describe Service::HipChat do
     it do
       message = 'hi'
       client = double(HipChat::Client)
-      HipChat::Client.should_receive(:new).with(config[:api_token]).and_return(client)
+      options = { :api_version => 'v1' }
+      HipChat::Client.should_receive(:new).with(config[:api_token], options).and_return(client)
       client.should_receive(:[]).with(config[:room]).and_return(client)
       client.should_receive(:send).with('Crashlytics', message, { :notify => config[:notify] })
 


### PR DESCRIPTION
This allows users to choose the url used by the
service integration. It will not affect current
users of the integration who did not enter a
url.