### PR TITLE
Changing notify config to bool

### DIFF
--- a/lib/service/schema.rb
+++ b/lib/service/schema.rb
@@ -64,7 +64,8 @@ module Service
     # Public: Adds the given attributes as Checkbox attributes in the Service's
     # schema. This will display a checkbox in the UI.
     #
-    # The value of this option will be true if the checkbox is checked and false otherwise.
+    # The value of this option will be the value specified in the "value" option.
+    # Otherwise, no value will be present in the config for the given identifier.
     #
     # Example:
     #

--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.13.0'
+  VERSION = '3.14.0'
 end

--- a/lib/services/hipchat.rb
+++ b/lib/services/hipchat.rb
@@ -51,12 +51,13 @@ class Service::HipChat < Service::Base
     room = config[:room]
     url = config[:url]
     api_version = config[:v2] ? 'v2' : 'v1'
+    notify = config[:notify] ? true : false
     options = { :api_version => api_version }
     server_url = url.to_s
     unless server_url.empty?
       options[:server_url] = server_url
     end
     client = HipChat::Client.new(token, options)
-    client[room].send('Crashlytics', message, :notify => config[:notify]) 
+    client[room].send('Crashlytics', message, :notify => notify)
   end
 end

--- a/spec/services/hipchat_spec.rb
+++ b/spec/services/hipchat_spec.rb
@@ -6,7 +6,7 @@ describe Service::HipChat do
     {
       :api_token => 'token',
       :room => 'room id',
-      :notify => false
+      :notify => nil
     }
   end
 
@@ -53,7 +53,7 @@ describe Service::HipChat do
       options = { :api_version => 'v1' }
       HipChat::Client.should_receive(:new).with(config[:api_token], options).and_return(client)
       client.should_receive(:[]).with(config[:room]).and_return(client)
-      client.should_receive(:send).with('Crashlytics', message, { :notify => config[:notify] })
+      client.should_receive(:send).with('Crashlytics', message, { :notify => false })
 
       Service::HipChat.new('verification', {}).send(:send_message, config, message)
     end


### PR DESCRIPTION
The values sent to the backend for
checkboxes are not booleans as the
documentation suggested. Passing a
non-boolean argument for the
'notify' option in the HipChat gem
causes an error when using API v2.
This change converts the notify
config option to a boolean.