### PR TITLE
Remove rake task in favor of documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,11 +35,4 @@ namespace :services do
 
     puts output
   end
-
-  desc 'Copy service_hooks.yml to other projects'
-  task :copy do
-    file = ENV['FILE'] || File.join(File.dirname(__FILE__), 'service_hooks.yml')
-    FileUtils.cp file, '/srv/crashlytics/config/www/service_hooks.yml'
-    FileUtils.cp file, '/srv/crashlytics/config/daemon/service_hooks.yml'
-  end
 end


### PR DESCRIPTION
The information about the config file location is subject to change and
not really the concern of the crashlytics-services gem.  Remove this
task in favor of documentation that can be updated with this info.