### PR TITLE
Fixes hipchat, pagerduty, and slack

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.16.2'
+  VERSION = '3.17.0'
 end

--- a/lib/services/hipchat.rb
+++ b/lib/services/hipchat.rb
@@ -27,8 +27,6 @@ class Service::HipChat < Service::Base
   def receive_issue_impact_change(config, payload)
     send_message(config, format_issue_impact_change_message(payload))
     :no_resource
-  rescue => e
-    log "Rescued an issue_impact_change error in HipChat: #{ e }"
   end
 
   private

--- a/lib/services/pagerduty.rb
+++ b/lib/services/pagerduty.rb
@@ -11,7 +11,7 @@ class Service::Pagerduty < Service::Base
     if resp.success?
       { :pagerduty_incident_key => JSON.parse(resp.body)['incident_key'] }
     else
-      log "Pagerduty issue impact change failed: #{resp[:status]}, payload: #{payload}"
+      raise "Pagerduty issue impact change failed: #{resp.status} - #{resp.body}"
     end
   end
 

--- a/lib/services/slack.rb
+++ b/lib/services/slack.rb
@@ -25,6 +25,7 @@ class Service::Slack < Service::Base
   def receive_issue_impact_change(config, payload)
     message, options = format_issue_impact_change_message(payload)
     send_message(config, message, options)
+    :no_resource
   end
 
   private

--- a/spec/services/hipchat_spec.rb
+++ b/spec/services/hipchat_spec.rb
@@ -58,6 +58,18 @@ describe Service::HipChat do
 
       expect(service.receive_issue_impact_change(config, payload)).to eq(:no_resource)
     end
+
+    it 'surfaces exceptions as runtime errors' do
+      payload = { :url => 'url', :app => { :name => 'name' },
+            :title => 'title', :method => 'method' }
+      service = Service::HipChat.new('issue_impact_change', {})
+
+      expect(service).to receive(:send_message).and_raise('Unhandled error')
+
+      expect {
+        service.receive_issue_impact_change(config, payload)
+      }.to raise_error(/Unhandled error/)
+    end
   end
 
   describe :send_message do

--- a/spec/services/pagerduty_spec.rb
+++ b/spec/services/pagerduty_spec.rb
@@ -93,8 +93,7 @@ describe Service::Pagerduty do
         .with('https://events.pagerduty.com/generic/2010-04-15/create_event.json')
         .and_return(test.post('/generic/2010-04-15/create_event.json'))
 
-      resp = @service.receive_issue_impact_change(@config, @payload)
-      expect(resp).to be_nil
+      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error(/500 - {\"incident_key\":\"foo\"}/)
     end
   end
 end

--- a/spec/services/slack_spec.rb
+++ b/spec/services/slack_spec.rb
@@ -60,12 +60,12 @@ describe Service::Slack do
           {:title=>"Bundle identifier", :value=>nil, :short=>"true"}]
       }
 
-      expect(service).to receive(:send_message).with(config,
-                                                 '<url|name> crashed 1 times in method!',
-                                                  :attachments=>[expected_attachment])
-                                            .and_return(true)
+      fake_response = double('response', :code => '200', :body => 'Unused')
+      expect_any_instance_of(Slack::Notifier).to receive(:ping).
+        with('<url|name> crashed 1 times in method!',
+          :attachments => [expected_attachment]).and_return(fake_response)
 
-      expect(service.receive_issue_impact_change(config, payload)).to be true
+      expect(service.receive_issue_impact_change(config, payload)).to be :no_resource
     end
 
     it 'bubbles up errors from Slack' do


### PR DESCRIPTION
Each was breaking the integration container contract in some way that
prevented errors or successes from being handled properly.

* Slack was not returning :no_resource on success, and send_message was
returning nil in most cases.
* Pagerduty was returning nil in the case of an unhandled error, thus
getting less helpful error reporting
* HipChat was returning nil in the case of an unhandled error, thus
getting less helpful error reporting