### PR TITLE
Fix crashlytics-services/issues/72

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.17.0'
+  VERSION = '3.17.1'
 end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'pp'
 require 'jira'
+require 'uri'
 
 class Service::Jira < Service::Base
   title "Jira"
@@ -162,17 +163,17 @@ class Service::Jira < Service::Base
     )
   end
 
-  private
-  require 'uri'
   def parse_url(url)
     uri = URI(url)
-    result = { :url_prefix => url.match(/(https?:\/\/.*?)\/browse\//)[1],
-      :project_key => uri.path.match(/\/browse\/(.+?)(\/|$)/)[1]}
+    result = { :url_prefix => url.match(/(https?:\/\/.*?)\/.+\//)[1],
+      :project_key => uri.path.match(/\/.+\/(.+?)(\/|$)/)[1]}
     result
   end
 
+  private
+
   def get_context_path(url)
-    m = url.match(/https?:\/\/.*?..+?((?:\/.+)+)\/browse\//)
+    m = url.match(/https?:\/\/.*?..+?((?:\/.+)+)\/.+\//)
     m ? m[1] : ''
   end
 


### PR DESCRIPTION
Allow both new and old-style URLs.

Resolves https://github.com/crashlytics/crashlytics-services/issues/72