### PR TITLE
Fix mishandled newline character

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.17.1'
+  VERSION = '3.17.2'
 end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -42,7 +42,7 @@ class Service::Jira < Service::Base
       "at least #{ payload[:crashes_count] } times.\n\n"
     end
 
-    issue_description = 'Crashlytics detected a new issue.\n' + \
+    issue_description = "Crashlytics detected a new issue.\n" + \
                  "#{ payload[:title] } in #{ payload[:method] }\n\n" + \
                  users_text + \
                  crashes_text + \


### PR DESCRIPTION
This uses double quotes to allow interpolation of `\n` as an actual newline.

Fixes: https://github.com/crashlytics/crashlytics-services/issues/87