### PR TITLE
Using Jira gem issue model for issue creation

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.17.3'
+  VERSION = '3.17.4'
 end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -51,15 +51,15 @@ class Service::Jira < Service::Base
       'issuetype' => {'id' => '1'} } }
 
     # The Jira client raises an HTTPError if the response is not of the type Net::HTTPSuccess
-    resp = client.post("#{url_components[:url_prefix]}/rest/api/2/issue", post_body.to_json)
-
-    body = JSON.parse(resp.body)
-    { :jira_story_id => body['id'], :jira_story_key => body['key'] }
+    issue = client.Issue.build
+    if issue.save(post_body)
+      { :jira_story_id => issue.id, :jira_story_key => issue.key }
+    else
+      raise "Jira Issue Create Failed: #{issue.respond_to?(:errors) ? issue.errors : {}}"
+    end
 
   rescue JIRA::HTTPError => e
     raise "Jira Issue Create Failed. Message: #{ e.message }, Status: #{ e.code }, Body: #{ e.response.body }"
-  rescue => e
-    raise "Jira Issue Create Failed: #{ e.message }"
   end
 
   def receive_verification(config, payload)

--- a/spec/services/jira_spec.rb
+++ b/spec/services/jira_spec.rb
@@ -106,17 +106,7 @@ describe Service::Jira do
 
       expect {
         @service.receive_issue_impact_change(@config, @payload)
-      }.to raise_error(/Status: 500, Body: {\"id\":\"foo\"}/)
-    end
-
-    it 'should handle and re-raise any non-HTTP errors' do
-      mock_client = double("Client")
-      allow(mock_client).to receive(:Project) {raise "Some Other Error"}
-      allow(@service).to receive(:jira_client).and_return(mock_client)
-
-      expect {
-        @service.receive_issue_impact_change(@config, @payload)
-      }.to raise_error(/Jira Issue Create Failed: Some Other Error/)
+      }.to raise_error(/Jira Issue Create Failed/)
     end
   end
 


### PR DESCRIPTION
Instead of hard coding the issue api url, allow the gem to build and
make the request in the 'receive_issue_impact_change' method. This may
resolve issues encountered with self-hosted JIRA such as Issue #72.

This also stops catching and rethrowing all exceptions in the
'receive_issue_impact_change' method. These errors should be handled by
the caller.