### PR TITLE
[3.19.1] Upgrade to RSpec 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+3.19.1
+-----
+- Update development version of RSpec to 3.3 and fix deprecated specs.
+- Add this CHANGELOG.md file.

--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.19.0'
+  VERSION = '3.19.1'
 end

--- a/service.gemspec
+++ b/service.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'webmock', '~> 1.20'
 end

--- a/spec/services/asana_spec.rb
+++ b/spec/services/asana_spec.rb
@@ -94,9 +94,9 @@ describe Service::Asana do
       it 'should raise if creating a new Asana task fails' do
         expect(service).to receive(:find_project).with(config[:api_key], project_id).and_return project
         expect(project).to receive(:workspace).and_return workspace
-        expect(workspace).to receive(:create_task).with(expected_task_options).and_raise
+        expect(workspace).to receive(:create_task).with(expected_task_options).and_raise('fake')
 
-        expect { service.receive_issue_impact_change config, issue }.to raise_error
+        expect { service.receive_issue_impact_change config, issue }.to raise_error(RuntimeError, /fake/)
       end
     end
   end

--- a/spec/services/campfire_spec.rb
+++ b/spec/services/campfire_spec.rb
@@ -88,8 +88,8 @@ describe Service::Campfire do
     end
 
     it 'should fail upon unsuccessful api response' do
-      expect(@room).to receive(:speak).and_return(nil)
-      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error
+      expect(@room).to receive(:speak).and_return(Hashie::Mash.new)
+      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error(/Campfire Message Post Failed/)
     end
   end
 end

--- a/spec/services/chatwork_spec.rb
+++ b/spec/services/chatwork_spec.rb
@@ -86,7 +86,7 @@ describe Service::ChatWork do
         .with("https://api.chatwork.com/v1/rooms/#{config[:room]}/messages")
         .and_return(test.post("v1/rooms/#{config[:room]}/messages"))
 
-      expect { @service.receive_issue_impact_change(config, @payload) }.to raise_error
+      expect { @service.receive_issue_impact_change(config, @payload) }.to raise_error(/Could not send a message to room/)
     end
   end
 end

--- a/spec/services/fogbugz_spec.rb
+++ b/spec/services/fogbugz_spec.rb
@@ -75,12 +75,12 @@ describe Service::FogBugz do
 
       it 'raises an exception given an error response' do
         expect(service).to receive(:http_post).and_return(double(Faraday::Response, :body => error_response))
-        expect { service.receive_issue_impact_change(config, payload) }.to raise_error
+        expect { service.receive_issue_impact_change(config, payload) }.to raise_error(/Could not create FogBugz/)
       end
 
       it 'raises an exception given an invalid response' do
         expect(service).to receive(:http_post).and_return(double(Faraday::Response, :body => invalid_response))
-        expect { service.receive_issue_impact_change(config, payload) }.to raise_error
+        expect { service.receive_issue_impact_change(config, payload) }.to raise_error(/Could not create FogBugz/)
       end
     end
   end

--- a/spec/services/pivotal_spec.rb
+++ b/spec/services/pivotal_spec.rb
@@ -97,7 +97,7 @@ describe Service::Pivotal do
         .with('https://www.pivotaltracker.com/services/v3/projects/foo_project/stories')
         .and_return(test.post('/services/v3/projects/foo_project/stories'))
 
-      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error
+      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error(/Pivotal Issue Create/)
     end
   end
 

--- a/spec/services/redmine_spec.rb
+++ b/spec/services/redmine_spec.rb
@@ -96,7 +96,7 @@ describe Service::Redmine do
         .with('http://redmine.acme.com/issues.json')
         .and_return(test.post('/issues.json'))
 
-      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error
+      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error(/Redmine Issue Create Failed/)
     end
   end
 end

--- a/spec/services/sprintly_spec.rb
+++ b/spec/services/sprintly_spec.rb
@@ -105,7 +105,7 @@ describe Service::Sprintly do
         .with('https://sprint.ly/api/products/1/items.json')
         .and_return(test.post('/api/products/1/items.json'))
 
-      expect { service.receive_issue_impact_change(config, payload) }.to raise_error
+      expect { service.receive_issue_impact_change(config, payload) }.to raise_error(/Adding defect to backlog failed/)
     end
   end
 end

--- a/spec/services/youtrack_spec.rb
+++ b/spec/services/youtrack_spec.rb
@@ -128,12 +128,12 @@ describe Service::YouTrack do
           }
         }).to_return(:status => 500, :body => {}.to_json)
 
-      expect { service.receive_issue_impact_change(config, issue_payload) }.to raise_exception
+      expect { service.receive_issue_impact_change(config, issue_payload) }.to raise_exception(/issue creation failed/)
     end
 
     it 'should fail if login fails' do
       stub_failed_login_for(config)
-      expect { service.receive_issue_impact_change(config, issue_payload) }.to raise_exception
+      expect { service.receive_issue_impact_change(config, issue_payload) }.to raise_exception(/Invalid login/)
     end
   end
 


### PR DESCRIPTION
- Update specs to look for specific error messages.  The generic
raise_error matcher is considered deprecated in RSpec 3.3
- Add CHANGELOG.md