### PR TITLE
Stop trying to parse Jira story-key

### DIFF
--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.26.0'
+  VERSION = '3.27.0'
 end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -53,7 +53,7 @@ class Service::Jira < Service::Base
     # The Jira client raises an HTTPError if the response is not of the type Net::HTTPSuccess
     issue = client.Issue.build
     if issue.save(post_body)
-      { :jira_story_id => issue.id, :jira_story_key => issue.key }
+      { :jira_story_id => issue.id }
     else
       raise "Jira Issue Create Failed - Errors are: #{issue.respond_to?(:errors) ? issue.errors : {}}"
     end

--- a/spec/services/jira_spec.rb
+++ b/spec/services/jira_spec.rb
@@ -87,10 +87,10 @@ describe Service::Jira do
          to_return(:status => 200, :body => '{"id":12345}')
 
       stub_request(:post, "https://example.com/rest/api/2/issue").
-         to_return(:status => 201, :body => '{"id":"foo","key":"bar"}')
+         to_return(:status => 201, :body => '{"id":"foo"}')
 
       resp = @service.receive_issue_impact_change(@config, @payload)
-      expect(resp).to eq({ :jira_story_id => 'foo', :jira_story_key => 'bar' })
+      expect(resp).to eq({ :jira_story_id => 'foo' })
     end
 
     it 'escalates error details if they are provided in the response body' do


### PR DESCRIPTION
This is a source of errors in some installations of Jira, and is not
yet used.