### PR TITLE
Stop using response.body in error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+3.28.0
+------
+- Generally reduce our use of response.body in describing errors.
+
 3.25.0
 ------
 - Simplify Redmine error reporting to demystify the test payload content that was confusing the UI.

--- a/lib/service/http.rb
+++ b/lib/service/http.rb
@@ -140,5 +140,32 @@ module Service
     rescue TimeoutError
       url
     end
+
+    # Public: Returns true for a 200-level response, false otherwise
+    #
+    # response - HTTP response to check for success
+    def successful_response?(response)
+      (200..299).include?(response.status)
+    end
+
+    # Public: produces an error detail message based on the HTTP response
+    #
+    # Note: it won't attempt to print out an entire HTML doc
+    #
+    # response - HTTP response to check for status code info
+    def error_response_details(response)
+      status_code_info = "HTTP status code: #{response.status}"
+      if discard_body?(response.body)
+        status_code_info
+      else
+        "#{status_code_info}, body: #{response.body}"
+      end
+    end
+
+    private
+
+    def discard_body?(body)
+      body =~ /!DOCTYPE/
+    end
   end
 end

--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.27.0'
+  VERSION = '3.28.0'
 end

--- a/lib/services/appaloosa.rb
+++ b/lib/services/appaloosa.rb
@@ -30,10 +30,6 @@ class Service::Appaloosa < Service::Base
     failure
   end
 
-  def successful_response?(response)
-    (200..299).include?(response.status)
-  end
-
   private
   # Post an event string to a url with a payload hash
   # Returns true if the response code is anything 2xx, else false
@@ -48,18 +44,5 @@ class Service::Appaloosa < Service::Base
       req.body                    = body.to_json
       req.params['verification']  = 1 if event == 'verification'
     end
-  end
-
-  def error_response_details(response)
-    status_code_info = "HTTP status code: #{response.status}"
-    if discard_body?(response.body)
-      status_code_info
-    else
-      "#{status_code_info}, body: #{response.body}"
-    end
-  end
-
-  def discard_body?(body)
-    body =~ /!DOCTYPE/
   end
 end

--- a/lib/services/bitbucket.rb
+++ b/lib/services/bitbucket.rb
@@ -59,7 +59,7 @@ class Service::Bitbucket < Service::Base
     if resp.status == 200
       [true, "Successfully verified Bitbucket settings"]
     else
-      log "HTTP Error: status code: #{ resp.status }, body: #{ resp.body }"
+      log "Verification error - #{error_response_details(resp)}"
       [false, "Oops! Please check your settings again."]
     end
   rescue => e
@@ -102,7 +102,7 @@ class Service::Bitbucket < Service::Base
     end
 
     if resp.status != 200
-      raise "Bitbucket issue creation failed: #{ resp.status }, body: #{ resp.body }"
+      raise "Bitbucket issue creation failed - #{error_response_details(resp)}"
     end
 
     { :bitbucket_issue_id => JSON.parse(resp.body)['local_id'] }

--- a/lib/services/hall.rb
+++ b/lib/services/hall.rb
@@ -14,7 +14,7 @@ class Service::Hall < Service::Base
     if successful_response?(response)
       :no_resource
     else
-      raise "Failed to send Hall message. HTTP status code: #{response.status}, body: #{response.body}"
+      raise "Failed to send Hall message - #{error_response_details(response)}"
     end
   end
 
@@ -48,10 +48,6 @@ class Service::Hall < Service::Base
       req.body                    = body.to_json
       req.params['verification']  = 1 if event == 'verification'
     end
-  end
-
-  def successful_response?(response)
-    (200..299).include?(response.status)
   end
 
   def verify_hall_service(config)

--- a/lib/services/moxtra.rb
+++ b/lib/services/moxtra.rb
@@ -12,7 +12,7 @@ class Service::Moxtra < Service::Base
       # return :no_resource if we don't have a resource identifier to save
       :no_resource
     else
-      raise "Moxtra WebHook issue create failed: HTTP status code: #{response.status}, body: #{response.body}"
+      raise "Moxtra WebHook issue create failed - #{error_response_details(response)}"
     end
   end
 
@@ -28,10 +28,6 @@ class Service::Moxtra < Service::Base
   rescue => e
     log "Received a verification error in Moxtra: (url=#{config[:url]}) #{e}"
     failure
-  end
-
-  def successful_response?(response)
-    (200..299).include?(response.status)
   end
 
   private

--- a/lib/services/opsgenie.rb
+++ b/lib/services/opsgenie.rb
@@ -11,9 +11,12 @@ class Service::OpsGenie < Service::Base
       :event          => 'issue_impact_change'
     }
     resp = post_to_opsgenie(config, body)
-    raise "OpsGenie issue creation failed: #{resp.status} - #{resp.body}" unless resp.success?
-    log "Issue impact change successfully submitted to OpsGenie: #{resp[:status]}, payload: #{payload}"
-    :no_resource
+    if resp.success?
+      log "Issue impact change successfully submitted to OpsGenie"
+      :no_resource
+    else
+      raise "OpsGenie issue creation failed - #{error_response_details(resp)}"
+    end
   end
 
   def receive_verification(config, _)

--- a/lib/services/pagerduty.rb
+++ b/lib/services/pagerduty.rb
@@ -11,7 +11,7 @@ class Service::Pagerduty < Service::Base
     if resp.success?
       { :pagerduty_incident_key => JSON.parse(resp.body)['incident_key'] }
     else
-      raise "Pagerduty issue impact change failed: #{resp.status} - #{resp.body}"
+      raise "Pagerduty issue impact change failed - #{error_response_details(resp)}"
     end
   end
 

--- a/lib/services/slack.rb
+++ b/lib/services/slack.rb
@@ -61,7 +61,7 @@ class Service::Slack < Service::Base
     response = client.ping(message, options)
 
     unless response.code == '200'
-      raise "Unexpected response from Slack: #{response.code}, #{response.body}"
+      raise "Unexpected response from Slack: #{response.code}"
     end
   end
 end

--- a/lib/services/sprintly.rb
+++ b/lib/services/sprintly.rb
@@ -22,7 +22,7 @@ class Service::Sprintly < Service::Base
       if resp.status == 200
         [true,  'Successfully verified Sprint.ly settings!']
       else
-        log "Sprint.ly HTTP Error, status code: #{ resp.status }, body: #{ resp.body }"
+        log "Sprint.ly error: #{error_response_details(resp)}"
         [false, "Oops! Please check your settings again."]
       end
     rescue => e
@@ -46,8 +46,12 @@ class Service::Sprintly < Service::Base
     resp = http_post url do |req|
       req.body = post_body
     end
-    raise "[Sprint.ly] Adding defect to backlog failed: #{ resp[:status] }, body: #{ resp.body }" unless resp.status == 200
-    { :sprintly_item_number => JSON.parse(resp.body)['number'] }
+
+    if resp.status == 200
+      { :sprintly_item_number => JSON.parse(resp.body)['number'] }
+    else
+      raise "[Sprint.ly] Adding defect to backlog failed - #{error_response_details(resp)}"
+    end
   end
 
   private

--- a/lib/services/web_hook.rb
+++ b/lib/services/web_hook.rb
@@ -30,10 +30,6 @@ class Service::WebHook < Service::Base
     failure
   end
 
-  def successful_response?(response)
-    (200..299).include?(response.status)
-  end
-
   private
 
   # Post an event string to a url with a payload hash
@@ -49,18 +45,5 @@ class Service::WebHook < Service::Base
       req.body                    = body.to_json
       req.params['verification']  = 1 if event == 'verification'
     end
-  end
-
-  def error_response_details(response)
-    status_code_info = "HTTP status code: #{response.status}"
-    if discard_body?(response.body)
-      status_code_info
-    else
-      "#{status_code_info}, body: #{response.body}"
-    end
-  end
-
-  def discard_body?(body)
-    body =~ /!DOCTYPE/
   end
 end

--- a/lib/services/zohoprojects.rb
+++ b/lib/services/zohoprojects.rb
@@ -16,7 +16,7 @@ class Service::ZohoProjects < Service::Base
 
     response = send_request_to_projects config, payload
     if response.status != 200
-      raise "Problem while sending request to Zoho Projects, Status: #{response.status}, Body: #{response.body}"
+      raise "Problem while sending request to Zoho Projects - #{error_response_details(response)}"
     end
 
     return { :zohoprojects_bug_id => response.body }

--- a/spec/services/bitbucket_spec.rb
+++ b/spec/services/bitbucket_spec.rb
@@ -151,7 +151,7 @@ describe Service::Bitbucket do
 
       expect {
         @service.receive_issue_impact_change(@config, @payload)
-      }.to raise_error(/Bitbucket issue creation failed: 500, body: fakebody/)
+      }.to raise_error('Bitbucket issue creation failed -  HTTP status code: 500, body: fakebody')
     end
   end
 end

--- a/spec/services/hall_spec.rb
+++ b/spec/services/hall_spec.rb
@@ -55,7 +55,7 @@ describe Service::Hall do
       allow(@service).to receive(:send_hall_message).with(@config, @payload) {@failure}
       expect {
         @service.receive_issue_impact_change(@config, @payload)
-      }.to raise_error(/Failed to send Hall message. HTTP status code: 404, body: fakebody/)
+      }.to raise_error(/Failed to send Hall message - HTTP status code: 404, body: fakebody/)
     end
   end
 end

--- a/spec/services/moxtra_spec.rb
+++ b/spec/services/moxtra_spec.rb
@@ -96,7 +96,7 @@ describe Service::Moxtra do
 
       expect {
         @service.receive_issue_impact_change(@config, @payload)
-      }.to raise_error(/Moxtra WebHook issue create failed: HTTP status code: 500, body: fake_body/)
+      }.to raise_error(/Moxtra WebHook issue create failed - HTTP status code: 500, body: fake_body/)
     end
   end
 end

--- a/spec/services/opsgenie_spec.rb
+++ b/spec/services/opsgenie_spec.rb
@@ -84,7 +84,7 @@ describe Service::OpsGenie do
         .with('https://api.opsgenie.com/v1/json/crashlytics')
         .and_return(test.post('/v1/json/crashlytics'))
 
-      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error 'OpsGenie issue creation failed: 500 - title not given'
+      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error 'OpsGenie issue creation failed - HTTP status code: 500, body: title not given'
     end
   end
 end

--- a/spec/services/pagerduty_spec.rb
+++ b/spec/services/pagerduty_spec.rb
@@ -93,7 +93,7 @@ describe Service::Pagerduty do
         .with('https://events.pagerduty.com/generic/2010-04-15/create_event.json')
         .and_return(test.post('/generic/2010-04-15/create_event.json'))
 
-      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error(/500 - {\"incident_key\":\"foo\"}/)
+      expect { @service.receive_issue_impact_change(@config, @payload) }.to raise_error(/500, body: {\"incident_key\":\"foo\"}/)
     end
   end
 end

--- a/spec/services/slack_spec.rb
+++ b/spec/services/slack_spec.rb
@@ -78,7 +78,7 @@ describe Service::Slack do
 
       expect {
         service.receive_issue_impact_change(config, payload)
-      }.to raise_error(/Unexpected response from Slack: 404, No service/)
+      }.to raise_error(/Unexpected response from Slack: 404/)
     end
   end
 
@@ -113,7 +113,7 @@ describe Service::Slack do
       success, message = Service::Slack.new('verification', {}).receive_verification(config, {})
 
       expect(success).to be false
-      expect(message).to eq('Could not send a message to channel mychannel. Unexpected response from Slack: 404, foo')
+      expect(message).to eq('Could not send a message to channel mychannel. Unexpected response from Slack: 404')
     end
   end
 end

--- a/spec/services/zohoprojects_spec.rb
+++ b/spec/services/zohoprojects_spec.rb
@@ -96,8 +96,7 @@ describe Service::ZohoProjects do
 
       expect {
         service.receive_issue_impact_change(config, payload)
-      }.to raise_error(
-        RuntimeError, 'Problem while sending request to Zoho Projects, Status: 400, Body: fake-error-body')
+      }.to raise_error('Problem while sending request to Zoho Projects - HTTP status code: 400, body: fake-error-body')
     end
   end
 end


### PR DESCRIPTION
* When possible, prefer status code only to avoid parsing problems from
misconfigured third-party services.  This should reduce the number of
errors overall, and surface relevant HTTP status code information more
consistently and reliably for troubleshooting purposes.