### PR TITLE
Changed issueType to use "name" key instead of issue type "id" key.

### DIFF
--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -48,7 +48,7 @@ class Service::Jira < Service::Base
       'project' => {'id' => project.id},
       'summary'     => payload[:title] + ' [Crashlytics]',
       'description' => issue_description,
-      'issuetype' => {'id' => '1'} } }
+      'issuetype' => {'name' => 'Bug'} } }
 
     # The Jira client raises an HTTPError if the response is not of the type Net::HTTPSuccess
     issue = client.Issue.build


### PR DESCRIPTION
After attempting to integrate Crashlytics with our publicly accessibly Jira project, I kept receiving a "{"issuetype"=>"valid issue type is required"}" error.  After a bit of digging, I discovered a user pointed out (https://twittercommunity.com/t/jira-integration-is-not-creating-tasks/56467/10) the post requested is assuming everyone's Bug issue type id is 1.  Our Bug issue type id is 10004, for example.  

Taking a look at Jira's create issue POST example, they are using the issue type "name" key instead of  instead of the "id" key.

source: https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis/jira-rest-api-tutorials/jira-rest-api-example-create-issue

Here's another quote from https://developer.atlassian.com/jiradev/jira-apis/jira-rest-apis: "Instead of using numeric identifiers for the project and issue type, you could have used the key and name of the type instead. "

(note: I haven't tested this.  I'm making an assumption that the example POST json on Jira's website is correct)

{
    "fields": {
       "project":
       { 
          "key": "TEST"
       },
       "summary": "REST ye merry gentlemen.",
       "description": "Creating of an issue using project keys and issue type names using the REST API",
       "issuetype": {
          "name": "Bug"
       }
   }
}