### PR TITLE
Fixes: https://github.com/crashlytics/crashlytics-services/issues/110…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+3.29.0
+------
+- Use Jira issueType name instead of ID, and allow it to be overridden
+
 3.28.0
 ------
 - Generally reduce our use of response.body in describing errors.

--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '3.28.0'
+  VERSION = '3.29.0'
 end

--- a/lib/services/jira.rb
+++ b/lib/services/jira.rb
@@ -15,6 +15,9 @@ class Service::Jira < Service::Base
                    'Your Jira username:'
   password :password, :placeholder => 'password',
          :label => 'Your Jira password:'
+  string :issue_type, :placeholder => 'Bug', :required => false,
+         :label => 'Issue Type: <br />' \
+                   'This should be the name of an issue type in your Jira project.'
 
   page "Project", [ :project_url ]
   page "Login Information", [ :username, :password ]
@@ -45,10 +48,12 @@ class Service::Jira < Service::Base
                  "More information: #{ payload[:url] }"
 
     post_body = { 'fields' => {
-      'project' => {'id' => project.id},
-      'summary'     => payload[:title] + ' [Crashlytics]',
-      'description' => issue_description,
-      'issuetype' => {'id' => '1'} } }
+        'project' => { 'id' => project.id },
+        'summary'     => payload[:title] + ' [Crashlytics]',
+        'description' => issue_description,
+        'issuetype' => { 'name' => config[:issue_type] || 'Bug' }
+      }
+    }
 
     # The Jira client raises an HTTPError if the response is not of the type Net::HTTPSuccess
     issue = client.Issue.build


### PR DESCRIPTION
Based off https://github.com/crashlytics/crashlytics-services/pull/114 and https://github.com/crashlytics/crashlytics-services/pull/121, includes some additional spec coverage, and makes issue type an optional field.