### PR TITLE
Update label to project ID

### DIFF
--- a/lib/services/gitlab.rb
+++ b/lib/services/gitlab.rb
@@ -4,7 +4,7 @@ class Service::GitLab < Service::Base
   title 'GitLab'
 
   string :url, :placeholder => 'https://gitlab.com', :label => 'Your GitLab URL:'
-  string :project, :placeholder => 'Namespace/Project Name', :label => 'Your GitLab Namespace/Project:'
+  string :project, :placeholder => 'Project Id', :label => 'Your Numeric GitLab Project Id:'
   password :private_token, :placeholder => 'GitLab Private Token', :label => 'Your GitLab Private Token:'
 
   def receive_verification


### PR DESCRIPTION
The gitlab api does not work well with project names as can be seen by the multitude of issues the have reported. They do however, supprort lookup by project id with no issue. Prompt the user to input the project id, rather than the project namespace and title.