### PR TITLE
Creates Asana task in the specified project

### DIFF
--- a/lib/services/asana.rb
+++ b/lib/services/asana.rb
@@ -67,6 +67,7 @@ class Service::Asana < Service::Base
 
   def create_task(project, issue)
     workspace_id = project['data']['workspace']['id']
+    project_id = project['data']['id']
 
     response = http_post("#{asana_url}/tasks") do |request|
       request.headers.merge!(request_headers)
@@ -75,7 +76,8 @@ class Service::Asana < Service::Base
           :workspace => workspace_id,
           :name => issue[:title],
           :notes => create_notes(issue),
-          :assignee => 'me'
+          :assignee => 'me',
+          :projects => [project_id]
         }
       }.to_json
     end

--- a/spec/services/asana_spec.rb
+++ b/spec/services/asana_spec.rb
@@ -94,7 +94,7 @@ describe Service::Asana, :type => :service do
 
       it 'should create a new Asana task' do
         stub_request(:post, "https://key:@app.asana.com/api/1.0/tasks").
-        and_return(:status => 200, :body => '')
+          and_return(:status => 200, :body => '')
 
         service.receive_issue_impact_change issue
         expect(logger).to have_received(:log).with('issue_impact_change successful')
@@ -121,8 +121,8 @@ describe Service::Asana, :type => :service do
         }
 
         stub_request(:post, "https://key:@app.asana.com/api/1.0/tasks").
-        with(:body => expected_task_body).
-        to_return(:status => 200, :body => "")
+          with(:body => expected_task_body).
+          to_return(:status => 200, :body => "")
      
         service.receive_issue_impact_change issue
         expect(logger).to have_received(:log).with('issue_impact_change successful')

--- a/spec/services/asana_spec.rb
+++ b/spec/services/asana_spec.rb
@@ -80,25 +80,21 @@ describe Service::Asana, :type => :service do
     describe :receive_issue_impact_change do
       let(:notes) { service.send :create_notes, issue }
       let(:project_id) { 'project_id_foo' }
-      let(:expected_task_options) do
-        {
-          :name => 'foo title',
-          :notes => notes,
-          :projects => [project_id]
-        }
-      end
+
       let(:project) { double(:id => project_id) }
       let(:workspace) { double(:id => 'workspace_id_foo') }
       let(:task) { double(:id => 'new_task_id') }
 
+ 
+
       before do
         stub_request(:get, "https://key:@app.asana.com/api/1.0/projects/project_id_foo").
-          and_return(:status => 200, :body => '{"data":{"workspace":{"id":1}}}')
+          and_return(:status => 200, :body => '{"data":{"id":123, "workspace":{"id":1}}}')
       end
 
       it 'should create a new Asana task' do
         stub_request(:post, "https://key:@app.asana.com/api/1.0/tasks").
-          and_return(:status => 200, :body => '')
+        and_return(:status => 200, :body => '')
 
         service.receive_issue_impact_change issue
         expect(logger).to have_received(:log).with('issue_impact_change successful')
@@ -112,6 +108,25 @@ describe Service::Asana, :type => :service do
           service.receive_issue_impact_change issue
         }.to raise_error(Service::DisplayableError, /Asana task creation failed/)
       end
+
+      it 'should send correct task creation body' do
+        expected_task_body = {
+          :data => {
+            :workspace => 1,
+            :name => 'foo title',
+            :notes => notes,
+            :assignee =>'me',
+            :projects => [123]
+          }
+        }
+
+        stub_request(:post, "https://key:@app.asana.com/api/1.0/tasks").
+        with(:body => expected_task_body).
+        to_return(:status => 200, :body => "")
+     
+        service.receive_issue_impact_change issue
+        expect(logger).to have_received(:log).with('issue_impact_change successful')
+        end
     end
   end
 end


### PR DESCRIPTION
Hi.

I'm using the Asana integration for my apps and I noticed that when I link it, the tasks are not created in the project I specified.

Expected outcome:
The task is created in the project I supplied in the integration UI with "me" as assignee.

Actual outcome:
The task is created as a private task on with "me" as assignee. 

## 

In order to fix this I read the asana documentation and found out that by adding the `projects` key to the data, then it the task is added in the correct project.

Equivalent curl request with `projects` field
```sh
curl -XPOST -H 'Authorization: Bearer access_token' -H "Content-type: application/json" \
 -d '{"data": { "assignee": "me", "notes": "This is my awesome note", "name": "asana api test", "workspace": "workpace_id", "projects": ["project_id"]}}' \ 
https://app.asana.com/api/1.0/tasks
```

About the `projects` field from the [asana documentation](https://asana.com/developers/api-reference/tasks)

> Create-only. Array of projects this task is associated with. At task creation time, this array can be used to add the task to many projects at once. After task creation, these associations can be modified using the addProject and removeProject endpoints.

##

I couldn't figure out how to start the server and try it out so I haven't executed the code.