### PR TITLE
Support for ChatWork API v2

### DIFF
--- a/lib/services/chatwork.rb
+++ b/lib/services/chatwork.rb
@@ -39,7 +39,7 @@ class Service::ChatWork < Service::Base
   end
 
   def send_message(config, message)
-    res = http_post "https://api.chatwork.com/v1/rooms/#{config[:room]}/messages" do |req|
+    res = http_post "https://api.chatwork.com/v2/rooms/#{config[:room]}/messages" do |req|
       req.headers['X-ChatWorkToken'] = config[:api_token]
       req.params['body'] = message
     end

--- a/spec/services/chatwork_spec.rb
+++ b/spec/services/chatwork_spec.rb
@@ -32,13 +32,13 @@ describe Service::ChatWork, :type => :service do
     it 'should fail upon unsuccessful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.post("v1/rooms/#{config[:room]}/messages") { [500, {}, ''] }
+          stub.post("v2/rooms/#{config[:room]}/messages") { [500, {}, ''] }
         end
       end
 
       expect(service).to receive(:http_post)
-        .with("https://api.chatwork.com/v1/rooms/#{config[:room]}/messages")
-        .and_return(test.post("v1/rooms/#{config[:room]}/messages"))
+        .with("https://api.chatwork.com/v2/rooms/#{config[:room]}/messages")
+        .and_return(test.post("v2/rooms/#{config[:room]}/messages"))
 
       expect(service).to receive(:verification_message)
 
@@ -68,14 +68,14 @@ describe Service::ChatWork, :type => :service do
     it 'should succeed upon successful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          response = '{"message_id":12345}'
-          stub.post("v1/rooms/#{config[:room]}/messages") { [201, {}, response] }
+          response = '{"message_id":"12345"}'
+          stub.post("v2/rooms/#{config[:room]}/messages") { [201, {}, response] }
         end
       end
 
       expect(service).to receive(:http_post)
-        .with("https://api.chatwork.com/v1/rooms/#{config[:room]}/messages")
-        .and_return(test.post("v1/rooms/#{config[:room]}/messages"))
+        .with("https://api.chatwork.com/v2/rooms/#{config[:room]}/messages")
+        .and_return(test.post("v2/rooms/#{config[:room]}/messages"))
 
       service.receive_issue_impact_change(payload)
       expect(logger).to have_received(:log).with('issue_impact_change successful')
@@ -84,13 +84,13 @@ describe Service::ChatWork, :type => :service do
     it 'should fail upon unsuccessful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.post("v1/rooms/#{config[:room]}/messages") { [500, {}, ''] }
+          stub.post("v2/rooms/#{config[:room]}/messages") { [500, {}, ''] }
         end
       end
 
       expect(service).to receive(:http_post)
-        .with("https://api.chatwork.com/v1/rooms/#{config[:room]}/messages")
-        .and_return(test.post("v1/rooms/#{config[:room]}/messages"))
+        .with("https://api.chatwork.com/v2/rooms/#{config[:room]}/messages")
+        .and_return(test.post("v2/rooms/#{config[:room]}/messages"))
 
       expect {
         service.receive_issue_impact_change(payload)


### PR DESCRIPTION
ChatWork API v1 is obsoleted to 2017/05/15.
ChatWork API change from v1 to v2.

http://support-en.chatwork.com/hc/en-us/articles/115000511946-01-26-2017-Chatwork-API-Update-Notice