### PR TITLE
Fix Gitlab service

### DIFF
--- a/lib/services/gitlab.rb
+++ b/lib/services/gitlab.rb
@@ -64,7 +64,7 @@ class Service::GitLab < Service::Base
   def project_url(project)
     project ||= ''
 
-    "#{config[:url]}/api/v3/projects/#{CGI.escape(project)}"
+    "#{config[:url]}/api/v4/projects/#{CGI.escape(project)}"
   end
 
   def project_issues_url(project)

--- a/spec/services/gitlab_spec.rb
+++ b/spec/services/gitlab_spec.rb
@@ -26,7 +26,7 @@ describe Service::GitLab, :type => :service do
 
   describe :receive_verification do
     it 'reports success' do
-      stub_request(:get, 'https://www.gitlabhq.com/api/v3/projects/root%2Fexample-project').
+      stub_request(:get, 'https://www.gitlabhq.com/api/v4/projects/root%2Fexample-project').
         with(:headers => { 'Private-Token' => 'foo_access_token' }).
         to_return(:status => 200, :body => '{"message":"Awesome"}')
 
@@ -35,7 +35,7 @@ describe Service::GitLab, :type => :service do
     end
 
     it 'reports failure details on an unsuccessful attempt' do
-      stub_request(:get, 'https://www.gitlabhq.com/api/v3/projects/root%2Fexample-project').
+      stub_request(:get, 'https://www.gitlabhq.com/api/v4/projects/root%2Fexample-project').
         with(:headers => { 'Private-Token' => 'foo_access_token' }).
         to_return(:status => 401, :body => '{"message":"401 Unauthorized"}')
 


### PR DESCRIPTION
Gitlab deprecated the v3 API and is returning 410 for all
of our calls. Luckily it looks like our integration
already works on the new API so we just need to update
the path to use v4.