### PR TITLE
Fix Pivotal to use v5 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+5.7.6
+-----
+- Fix Pivotal to use v5 API
+
 5.7.4
 -----
 - Assign Asana tasks to the configured project.

--- a/lib/service/version.rb
+++ b/lib/service/version.rb
@@ -1,3 +1,3 @@
 module Service
-  VERSION = '5.7.5'
+  VERSION = '5.7.6'
 end

--- a/lib/services/pivotal.rb
+++ b/lib/services/pivotal.rb
@@ -31,15 +31,13 @@ class Service::Pivotal < Service::Base
                  "More information: #{ payload[:url] }"
     post_body = {
       'name'     => payload[:title] + ' [Crashlytics]',
-      'requested_by'  => 'Crashlytics',
       'story_type'    => 'bug',
       'description' => issue_body }
 
-    resp = http_post "https://#{url_prefix}/services/v3/projects/#{project_id}/stories" do |req|
-      req.headers['Content-Type'] = 'application/xml'
+    resp = http_post "https://#{url_prefix}/services/v5/projects/#{project_id}/stories" do |req|
+      req.headers['Content-Type'] = 'application/json'
       req.headers['X-TrackerToken'] = config[:api_key]
-      req.params[:token] = config[:api_key]
-      req.body = post_to_xml(post_body)
+      req.body = post_body.to_json
     end
     if resp.success?
       log('issue_impact_change successful')
@@ -54,7 +52,7 @@ class Service::Pivotal < Service::Base
     project_id = parsed[:project_id]
     http.ssl[:verify] = true
 
-    resp = http_get "https://#{url_prefix}/services/v3/projects/#{project_id}" do |req|
+    resp = http_get "https://#{url_prefix}/services/v5/projects/#{project_id}/webhooks" do |req|
       req.headers['X-TrackerToken'] = config[:api_key]
     end
     if resp.status == 200
@@ -72,25 +70,5 @@ class Service::Pivotal < Service::Base
       :url_prefix => uri.hostname,
       :project_id => uri.path.match(/\/projects\/(.+?)(\/|$)/)[1]
     }
-  end
-
-  private
-  def post_to_xml(contents)
-    builder = ::Nokogiri::XML::Builder.new do |xml|
-      xml.story {
-        xml.name "#{contents['name']}"
-        xml.description "#{contents['description']}"
-        xml.story_type "#{contents['story_type']}"
-        # xml.estimate "#{contents['estimate']}"
-        # xml.current_state "#{contents['current_state']}"
-        # xml.requested_by "#{contents['requested_by']}"
-        # xml.owned_by "#{contents['owned_by']}"
-        # xml.labels "#{contents['labels']}"
-        # xml.project_id "#{contents['project_id']}"
-        # xml.other_id "#{contents['other_id']}"
-        # xml.integration_id "#{contents['integration_id']}"
-      }
-    end
-    builder.to_xml
   end
 end

--- a/spec/services/pivotal_spec.rb
+++ b/spec/services/pivotal_spec.rb
@@ -23,13 +23,13 @@ describe Service::Pivotal, :type => :service do
     it 'should succeed upon successful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.get('/services/v3/projects/foo_project') { [200, {}, ''] }
+          stub.get('/services/v5/projects/foo_project/webhooks') { [200, {}, ''] }
         end
       end
 
       expect(@service).to receive(:http_get)
-        .with('https://www.pivotaltracker.com/services/v3/projects/foo_project')
-        .and_return(test.get('/services/v3/projects/foo_project'))
+        .with('https://www.pivotaltracker.com/services/v5/projects/foo_project/webhooks')
+        .and_return(test.get('/services/v5/projects/foo_project/webhooks'))
 
       @service.receive_verification
       expect(@logger).to have_received(:log).with('verification successful')
@@ -38,13 +38,13 @@ describe Service::Pivotal, :type => :service do
     it 'should fail upon unsuccessful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.get('/services/v3/projects/foo_project') { [500, {}, ''] }
+          stub.get('/services/v5/projects/foo_project/webhooks') { [500, {}, ''] }
         end
       end
 
       expect(@service).to receive(:http_get)
-        .with('https://www.pivotaltracker.com/services/v3/projects/foo_project')
-        .and_return(test.get('/services/v3/projects/foo_project'))
+        .with('https://www.pivotaltracker.com/services/v5/projects/foo_project/webhooks')
+        .and_return(test.get('/services/v5/projects/foo_project/webhooks'))
 
       expect {
         @service.receive_verification
@@ -69,14 +69,14 @@ describe Service::Pivotal, :type => :service do
     it 'should succeed upon successful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          response = '<?xml version="1.0" encoding="UTF-8"?><story><id type="integer">foo_id</id></story>'
-          stub.post('/services/v3/projects/foo_project/stories') { [201, {}, response] }
+          response = {:id => 'foo_id'}.to_json
+          stub.post('/services/v5/projects/foo_project/stories') { [201, {}, response] }
         end
       end
 
       expect(@service).to receive(:http_post)
-        .with('https://www.pivotaltracker.com/services/v3/projects/foo_project/stories')
-        .and_return(test.post('/services/v3/projects/foo_project/stories'))
+        .with('https://www.pivotaltracker.com/services/v5/projects/foo_project/stories')
+        .and_return(test.post('/services/v5/projects/foo_project/stories'))
 
       @service.receive_issue_impact_change(@payload)
       expect(@logger).to have_received(:log).with('issue_impact_change successful')
@@ -85,13 +85,13 @@ describe Service::Pivotal, :type => :service do
     it 'should fail upon unsuccessful api response' do
       test = Faraday.new do |builder|
         builder.adapter :test do |stub|
-          stub.post('/services/v3/projects/foo_project/stories') { [500, {}, ''] }
+          stub.post('/services/v5/projects/foo_project/stories') { [500, {}, ''] }
         end
       end
 
       expect(@service).to receive(:http_post)
-        .with('https://www.pivotaltracker.com/services/v3/projects/foo_project/stories')
-        .and_return(test.post('/services/v3/projects/foo_project/stories'))
+        .with('https://www.pivotaltracker.com/services/v5/projects/foo_project/stories')
+        .and_return(test.post('/services/v5/projects/foo_project/stories'))
 
       expect {
         @service.receive_issue_impact_change(@payload)


### PR DESCRIPTION
We were using an old version of their API (v3) which stopped working. This updates PR updates the Pivotal service hook to use their most recent API (v5).
